### PR TITLE
Fix an odd fail case when used in [tool] context

### DIFF
--- a/addons/GDMEC/Timing.cs
+++ b/addons/GDMEC/Timing.cs
@@ -2225,7 +2225,7 @@ public static class MECExtensionMethods2
     /// <returns>The modified coroutine handle.</returns>
     public static IEnumerator<double> CancelWith(this IEnumerator<double> coroutine, Node node)
     {
-        while (MEC.Timing.MainThread != System.Threading.Thread.CurrentThread || (IsNodeAlive(node) && coroutine.MoveNext()))
+        while ((IsNodeAlive(node) && coroutine.MoveNext() || MEC.Timing.MainThread != System.Threading.Thread.CurrentThread))
             yield return coroutine.Current;
     }
 
@@ -2238,7 +2238,7 @@ public static class MECExtensionMethods2
     /// <returns>The modified coroutine handle.</returns>
     public static IEnumerator<double> CancelWith(this IEnumerator<double> coroutine, Node node1, Node node2)
     {
-        while (MEC.Timing.MainThread != System.Threading.Thread.CurrentThread || (IsNodeAlive(node1) && IsNodeAlive(node2) && coroutine.MoveNext()))
+        while ((IsNodeAlive(node1) && IsNodeAlive(node2) && coroutine.MoveNext()) || MEC.Timing.MainThread != System.Threading.Thread.CurrentThread)
             yield return coroutine.Current;
     }
 
@@ -2253,7 +2253,7 @@ public static class MECExtensionMethods2
     public static IEnumerator<double> CancelWith(this IEnumerator<double> coroutine,
         Node node1, Node node2, Node node3)
     {
-        while (MEC.Timing.MainThread != System.Threading.Thread.CurrentThread || (IsNodeAlive(node1) && IsNodeAlive(node2) && IsNodeAlive(node3) && coroutine.MoveNext()))
+        while ((IsNodeAlive(node1) && IsNodeAlive(node2) && IsNodeAlive(node3) && coroutine.MoveNext()) || MEC.Timing.MainThread != System.Threading.Thread.CurrentThread)
             yield return coroutine.Current;
     }
 }


### PR DESCRIPTION
I've been using this system to bake map data in editor mode, and I've come across an extremely strange failcase when "hot-reloading". After hot-reloading for the first time after opening a project, coroutines wrapped in CancelWith() will stop working. I've done some tests and it appears that only in editor mode and only after building the project once, something is changed in the way c# handles logical comparisons, entirely skipping the right side of any or(||) statement if the left is already true. As the MoveNext() call is on the right side of the statement it is skipped. I think. Everything I know about the language says that's not how it works, but I also know very little about the fine details of compiler magic. Either way thats what appears to be happening and a fix based on that assumption does work. 

Linked below is a video of the failure and fix, and the repro project in case you want to poke around at it and find something more elegant.
https://youtu.be/b1UKvNSymVw
[coroutineworker.zip](https://github.com/user-attachments/files/19515202/coroutineworker.zip)

Said fix is implemented into this pull request. 

Thanks for making this btw, made my switch from Unity to Godot soooooo much smoother. Cheers.